### PR TITLE
Add get_clients

### DIFF
--- a/tellduslive.py
+++ b/tellduslive.py
@@ -343,6 +343,11 @@ class Session:
             return (devices is not None and
                     sensors is not None)
 
+    def get_clients(self):
+        """Request list of clients (Telldus devices) from server."""
+        res = self._request('clients/list')
+        return res.get('client') if res else None
+
     def device(self, device_id):
         """Return a device object."""
         return Device(self, device_id)

--- a/tellduslive.py
+++ b/tellduslive.py
@@ -343,6 +343,11 @@ class Session:
             return (devices is not None and
                     sensors is not None)
 
+    def request_info(self, device_id):
+        """Request device info."""
+        res = self._request('device/info', id=device_id)
+        return res if res else None
+
     def get_clients(self):
         """Request list of clients (Telldus devices) from server."""
         res = self._request('clients/list')
@@ -460,6 +465,12 @@ class Device:
             return int(self.statevalue)
         except (TypeError, ValueError):
             return None
+
+    def info(self):
+        """Retrive device info."""
+        if self.is_sensor:
+            return self.device
+        return self._session.request_info(self.device_id)
 
     def turn_on(self):
         """Turn device on."""


### PR DESCRIPTION
HomeAssistant can show hubs (called clients in TelldusLive) as shown below, this change adds possibility to get associated hubs from the cloud (I'm not sure what the local api will return).

<img width="672" alt="screenshot 2018-11-28 at 21 34 20" src="https://user-images.githubusercontent.com/676999/49180651-90afa500-f355-11e8-8ea2-dba8702d1ac9.png">
