### PR TITLE
Change api.telldus.com to pa-api.telldus.com

### DIFF
--- a/tellduslive.py
+++ b/tellduslive.py
@@ -14,10 +14,10 @@ __version__ = "0.10.10"
 
 _LOGGER = logging.getLogger(__name__)
 
-TELLDUS_LIVE_API_URL = "https://api.telldus.com/json/"
-TELLDUS_LIVE_REQUEST_TOKEN_URL = "https://api.telldus.com/oauth/requestToken"
-TELLDUS_LIVE_AUTHORIZE_URL = "https://api.telldus.com/oauth/authorize"
-TELLDUS_LIVE_ACCESS_TOKEN_URL = "https://api.telldus.com/oauth/accessToken"
+TELLDUS_LIVE_API_URL = "https://pa-api.telldus.com/json/"
+TELLDUS_LIVE_REQUEST_TOKEN_URL = "https://pa-api.telldus.com/oauth/requestToken"
+TELLDUS_LIVE_AUTHORIZE_URL = "https://pa-api.telldus.com/oauth/authorize"
+TELLDUS_LIVE_ACCESS_TOKEN_URL = "https://pa-api.telldus.com/oauth/accessToken"
 
 TELLDUS_LOCAL_API_URL = "http://{host}/api/"
 TELLDUS_LOCAL_REQUEST_TOKEN_URL = "http://{host}/api/token"


### PR DESCRIPTION
Hi, I had to do this fix to be able to connect to Telldus using Home Assistant. It was suggested by @GFBsoul in this thread: https://github.com/home-assistant/home-assistant/issues/21689#issuecomment-549121535

The same change was recommended by Telldus themselves at 2018-02-28: *As some of you have noticed, there is a difference between servers regarding what SSL versions they accept. We are only using api.telldus.com for TelldusCenter and that URL is now considered legacy. If you are connecting to our API using SSL, you should use pa-api.telldus.com instead.*
https://pa-api.telldus.com/

Cheers