### PR TITLE
Fix license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ setup(
     version="0.10.11",
     description="Communicate with Telldus Live",
     url="https://github.com/molobrakos/tellduslive",
-    license="",
     author="Erik",
     author_email="error.errorsson@gmail.com",
     install_requires=["requests", "requests_oauthlib"],
@@ -15,4 +14,7 @@ setup(
     provides=["tellduslive"],
     scripts=["tellduslive"],
     extras_require={"console": ["docopt"]},
+    classifiers=[
+        "License :: OSI Approved :: The Unlicense (Unlicense)"
+    ],
 )


### PR DESCRIPTION
Hey 👋🏻,

I am currently looking into licensing at Home Assistant, and I found that we could not detect the license of this library properly. According to pyproject.toml documentation about the `license` field:
> If you are using a standard, well-known license, it is not necessary to use this field. Instead, you should use one of the [classifiers](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#classifiers) starting with License ::. (As a general rule, it is a good idea to use a standard, well-known license, both to avoid confusion and because some organizations avoid software whose license is unapproved.)

If you could do a release after this PR, and maybe bump in Home Assistant, that would be awesome :)